### PR TITLE
Create ReportingMigrations over plain CassandraMigrations, and fix an…

### DIFF
--- a/project/PillarBuild.scala
+++ b/project/PillarBuild.scala
@@ -10,6 +10,7 @@ object PillarBuild extends Build {
   val assemblyMergeStrategySetting = mergeStrategy in assembly <<= (mergeStrategy in assembly) {
     (old) => {
       case PathList("javax", "servlet", xs@_*) => MergeStrategy.first
+      case "META-INF/io.netty.versions.properties" => MergeStrategy.last
       case x => old(x)
     }
   }

--- a/src/main/scala/de/kaufhof/pillar/cli/App.scala
+++ b/src/main/scala/de/kaufhof/pillar/cli/App.scala
@@ -30,8 +30,7 @@ class App(reporter: Reporter) {
 
   def run(arguments: Array[String]) {
     val commandLineConfiguration = CommandLineConfiguration.buildFromArguments(arguments)
-    val registry = Registry.fromDirectory(new File(commandLineConfiguration.migrationsDirectory, commandLineConfiguration.dataStore))
-
+    val registry = Registry.fromDirectory(new File(commandLineConfiguration.migrationsDirectory, commandLineConfiguration.dataStore), reporter)
     val dataStoreName = commandLineConfiguration.dataStore
     val environment = commandLineConfiguration.environment
 


### PR DESCRIPTION
… issue with "sbt assembly."

In this PR, I'm fixing the following issue when using `sbt assembly`:

``` scala
[info] Including from cache: scala-library-2.11.1.jar
java.lang.RuntimeException: deduplicate: different file contents found in the following:
/Users/justin.potter/.ivy2/cache/io.netty/netty-buffer/jars/netty-buffer-4.0.33.Final.jar:META-INF/io.netty.versions.properties
/Users/justin.potter/.ivy2/cache/io.netty/netty-codec/jars/netty-codec-4.0.33.Final.jar:META-INF/io.netty.versions.properties
/Users/justin.potter/.ivy2/cache/io.netty/netty-common/jars/netty-common-4.0.33.Final.jar:META-INF/io.netty.versions.properties
/Users/justin.potter/.ivy2/cache/io.netty/netty-handler/jars/netty-handler-4.0.33.Final.jar:META-INF/io.netty.versions.properties
/Users/justin.potter/.ivy2/cache/io.netty/netty-transport/jars/netty-transport-4.0.33.Final.jar:META-INF/io.netty.versions.properties
        at sbtassembly.Plugin$Assembly$.sbtassembly$Plugin$Assembly$$applyStrategy$1(Plugin.scala:205)
        at sbtassembly.Plugin$Assembly$$anonfun$11.apply(Plugin.scala:219)
        at sbtassembly.Plugin$Assembly$$anonfun$11.apply(Plugin.scala:217)
        at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
        at scala.collection.TraversableLike$$anonfun$flatMap$1.apply(TraversableLike.scala:251)
        at scala.collection.immutable.HashMap$HashMap1.foreach(HashMap.scala:224)
        at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:403)
        at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:403)
        at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:403)
        at scala.collection.immutable.HashMap$HashTrieMap.foreach(HashMap.scala:403)
        at scala.collection.TraversableLike$class.flatMap(TraversableLike.scala:251)
        at scala.collection.AbstractTraversable.flatMap(Traversable.scala:105)
        at sbtassembly.Plugin$Assembly$.applyStrategies(Plugin.scala:221)
        at sbtassembly.Plugin$Assembly$.apply(Plugin.scala:171)
        at sbtassembly.Plugin$.sbtassembly$Plugin$$assemblyTask(Plugin.scala:157)
        at sbtassembly.Plugin$$anonfun$baseAssemblySettings$6.apply(Plugin.scala:366)
        at sbtassembly.Plugin$$anonfun$baseAssemblySettings$6.apply(Plugin.scala:365)
        at scala.Function10$$anonfun$tupled$1.apply(Function10.scala:35)
        at scala.Function10$$anonfun$tupled$1.apply(Function10.scala:34)
        at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
        at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
        at sbt.std.Transform$$anon$4.work(System.scala:63)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
        at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
        at sbt.Execute.work(Execute.scala:237)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
        at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
        at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
[error] (*:assembly) deduplicate: different file contents found in the following:
[error] /Users/justin.potter/.ivy2/cache/io.netty/netty-buffer/jars/netty-buffer-4.0.33.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/justin.potter/.ivy2/cache/io.netty/netty-codec/jars/netty-codec-4.0.33.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/justin.potter/.ivy2/cache/io.netty/netty-common/jars/netty-common-4.0.33.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/justin.potter/.ivy2/cache/io.netty/netty-handler/jars/netty-handler-4.0.33.Final.jar:META-INF/io.netty.versions.properties
[error] /Users/justin.potter/.ivy2/cache/io.netty/netty-transport/jars/netty-transport-4.0.33.Final.jar:META-INF/io.netty.versions.properties
```

Also, I fixed an issue where we were missing the `reporter` when creating migrations, should get us some additional, useful output.

Thanks!

Justin Potter (not to be confused with the other Justin 😉 )
