### PR TITLE
fixes #11: initialize method is split up into two methods.

### DIFF
--- a/src/main/scala/de/kaufhof/pillar/Migrator.scala
+++ b/src/main/scala/de/kaufhof/pillar/Migrator.scala
@@ -19,5 +19,9 @@ trait Migrator {
 
   def initialize(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy = SimpleStrategy())
 
+  def createKeyspace(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy = SimpleStrategy())
+
+  def createMigrationsTable(session: Session, keyspace: String)
+
   def destroy(session: Session, keyspace: String)
 }

--- a/src/main/scala/de/kaufhof/pillar/PrintStreamReporter.scala
+++ b/src/main/scala/de/kaufhof/pillar/PrintStreamReporter.scala
@@ -6,9 +6,6 @@ import java.util.Date
 import com.datastax.driver.core.Session
 
 class PrintStreamReporter(stream: PrintStream) extends Reporter {
-  override def initializing(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy) {
-    stream.println(s"Initializing $keyspace")
-  }
 
   override def migrating(session: Session, dateRestriction: Option[Date]) {
     stream.println(s"Migrating with date restriction $dateRestriction")
@@ -25,4 +22,13 @@ class PrintStreamReporter(stream: PrintStream) extends Reporter {
   override def destroying(session: Session, keyspace: String) {
     stream.println(s"Destroying $keyspace")
   }
+
+  override def creatingKeyspace(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy): Unit = {
+    stream.println(s"Creating keyspace $keyspace")
+  }
+
+  override def creatingMigrationsTable(session: Session, keyspace: String): Unit = {
+    stream.println(s"Creating migrations-table in keyspace $keyspace")
+  }
+
 }

--- a/src/main/scala/de/kaufhof/pillar/Reporter.scala
+++ b/src/main/scala/de/kaufhof/pillar/Reporter.scala
@@ -5,9 +5,10 @@ import java.util.Date
 import com.datastax.driver.core.Session
 
 trait Reporter {
-  def initializing(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy)
   def migrating(session: Session, dateRestriction: Option[Date])
   def applying(migration: Migration)
   def reversing(migration: Migration)
   def destroying(session: Session, keyspace: String)
+  def creatingKeyspace(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy)
+  def creatingMigrationsTable(session: Session, keyspace: String)
 }

--- a/src/main/scala/de/kaufhof/pillar/ReportingMigrator.scala
+++ b/src/main/scala/de/kaufhof/pillar/ReportingMigrator.scala
@@ -6,8 +6,8 @@ import com.datastax.driver.core.Session
 
 class ReportingMigrator(reporter: Reporter, wrapped: Migrator) extends Migrator {
   override def initialize(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy) {
-    reporter.initializing(session, keyspace, replicationStrategy)
-    wrapped.initialize(session, keyspace, replicationStrategy)
+    createKeyspace(session, keyspace, replicationStrategy)
+    createMigrationsTable(session, keyspace)
   }
 
   override def migrate(session: Session, dateRestriction: Option[Date] = None) {
@@ -18,5 +18,15 @@ class ReportingMigrator(reporter: Reporter, wrapped: Migrator) extends Migrator 
   override def destroy(session: Session, keyspace: String) {
     reporter.destroying(session, keyspace)
     wrapped.destroy(session, keyspace)
+  }
+
+  override def createKeyspace(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy): Unit = {
+    reporter.creatingKeyspace(session, keyspace, replicationStrategy)
+    wrapped.createKeyspace(session, keyspace, replicationStrategy)
+  }
+
+  override def createMigrationsTable(session: Session, keyspace: String): Unit = {
+    reporter.creatingMigrationsTable(session, keyspace)
+    wrapped.createMigrationsTable(session, keyspace)
   }
 }

--- a/src/test/scala/de/kaufhof/pillar/PrintStreamReporterSpec.scala
+++ b/src/test/scala/de/kaufhof/pillar/PrintStreamReporterSpec.scala
@@ -17,10 +17,17 @@ class PrintStreamReporterSpec extends FunSpec with MockitoSugar with Matchers wi
   val replicationStrategy = SimpleStrategy()
   val nl = System.lineSeparator()
 
-  describe("#initializing") {
+  describe("#creatingKeyspace") {
     it("should print to the stream") {
-      reporter.initializing(session, keyspace, replicationStrategy)
-      output.toString should equal(s"Initializing myks${nl}")
+      reporter.creatingKeyspace(session, keyspace, replicationStrategy)
+      output.toString should equal(s"Creating keyspace myks${nl}")
+    }
+  }
+
+  describe("#creatingMigrationsTable") {
+    it("should print to the stream") {
+      reporter.creatingMigrationsTable(session, keyspace)
+      output.toString should equal(s"Creating migrations-table in keyspace myks${nl}")
     }
   }
 

--- a/src/test/scala/de/kaufhof/pillar/ReportingMigratorSpec.scala
+++ b/src/test/scala/de/kaufhof/pillar/ReportingMigratorSpec.scala
@@ -16,12 +16,9 @@ class ReportingMigratorSpec extends FunSpec with MockitoSugar {
     val replicationStrategy = SimpleStrategy()
     migrator.initialize(session, keyspace, replicationStrategy)
 
-    it("reports the initialize action") {
-      verify(reporter).initializing(session, keyspace, replicationStrategy)
-    }
-
-    it("delegates to the wrapped migrator") {
-      verify(wrapped).initialize(session, keyspace, replicationStrategy)
+    it("delegates to both createKeyspace and createMigrationsTable of the wrapped migrator") {
+      verify(wrapped).createKeyspace(session, keyspace, replicationStrategy)
+      verify(wrapped).createMigrationsTable(session, keyspace)
     }
   }
 


### PR DESCRIPTION
Backwards compatible due to an extension of the api.
