### PR TITLE
Remove sbt-dependency-graph from plugins.sbt

### DIFF
--- a/project/PillarBuild.scala
+++ b/project/PillarBuild.scala
@@ -62,7 +62,7 @@ object PillarBuild extends Build {
   lazy val root = Project(
     id = "pillar",
     base = file("."),
-    settings = Defaults.coreDefaultSettings ++ sbtassembly.Plugin.assemblySettings ++ net.virtualvoid.sbt.graph.Plugin.graphSettings ++ Sonatype.sonatypeSettings
+    settings = Defaults.coreDefaultSettings ++ sbtassembly.Plugin.assemblySettings ++ Sonatype.sonatypeSettings
   ).settings(
     assemblyMergeStrategySetting,
     assemblyTestSetting,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.9.0")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
-
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")


### PR DESCRIPTION
sbt-dependency-graph is a global plugin and should be used as it.
