### PR TITLE
Allow changing the name of the applied_migrations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,11 @@ Reference the acceptance spec suite for details.
 
 ### Release Notes
 
+#### Unreleased
 
+ * Added the option to specify the name of the applied_migrations table in which the migrations are stored. This is useful
+   when using pillar in a muli-module setup where the services have their own non shared tables but live both in the same keyspace
+   and should be deployed independently from each other
 
 #### 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -273,9 +273,48 @@ Reference the acceptance spec suite for details.
 
 ### Release Notes
 
-#### 1.0.1
 
-* Add a "destroy" method to drop a keyspace (iamsteveholmes)
+
+#### 3.3.0
+
+ * initialize-method split up into two methods (createKeyspace and createMigrationsTable). 
+
+#### 3.2.0
+
+* travis.yml file
+* travis build status in README
+* add replication strategy support [#1]:https://github.com/Galeria-Kaufhof/pillar/commit/e7429d52b21fb75a52c0756dc53abf930080a4e3
+* tweaked scaladoc for CassandraSpec
+* quorum consistency [#2]:https://github.com/Galeria-Kaufhof/pillar/commit/2a956146c6ed6d3137ba59ecb3752718c03882a9
+* add replication strategy support [#9]:https://github.com/Galeria-Kaufhof/pillar/pull/9
+* small bugfixes
+
+#### 3.1.0
+
+* Allow authentication and ssl connections (convoi)
+* Small bugfixes
+
+#### 3.0.0
+
+* change package structure to de.kaufhof (MarcoPriebe)
+
+#### 2.1.1
+
+* Update to sbt-sonatype dependency to version 1.1 (MarcoPriebe)
+* Update to Scala to version 2.11.6 (MarcoPriebe)
+
+#### 2.1.0
+
+* Update to Cassandra dependency to version 3.0.0 (MarcoPriebe)
+
+#### 2.0.1
+
+* Update a argot dependency to version 1.0.3 (magro)
+
+#### 2.0.0
+
+* Allow configuration of Cassandra port (fkoehler)
+* Rework Migrator interface to allow passing a Session object when integrating Pillar as a library (magro, comeara)
 
 #### 1.0.3
 
@@ -286,42 +325,7 @@ Reference the acceptance spec suite for details.
 * Shutdown cluster in migrate & initialize (magro)
 * Transition support from StreamSend to Chris O'Meara (comeara)
 
-#### 2.0.0
+#### 1.0.1
 
-* Allow configuration of Cassandra port (fkoehler)
-* Rework Migrator interface to allow passing a Session object when integrating Pillar as a library (magro, comeara)
+* Add a "destroy" method to drop a keyspace (iamsteveholmes)
 
-#### 2.0.1
-
-* Update a argot dependency to version 1.0.3 (magro)
-
-### 2.1.0
-
-* Update to Cassandra dependency to version 3.0.0 (MarcoPriebe)
-
-### 2.1.1
-
-* Update to sbt-sonatype dependency to version 1.1 (MarcoPriebe)
-* Update to Scala to version 2.11.6 (MarcoPriebe)
-
-### 3.0.0
-
-* change package structure to de.kaufhof (MarcoPriebe)
-
-### 3.1.0
-
-* Allow authentication and ssl connections (convoi)
-* Small bugfixes
-
-### 3.2.0
-
-* travis.yml file
-* travis build status in README
-* add replication strategy support [#1]:https://github.com/Galeria-Kaufhof/pillar/commit/e7429d52b21fb75a52c0756dc53abf930080a4e3
-* tweaked scaladoc for CassandraSpec
-* quorum consistency [#2]:https://github.com/Galeria-Kaufhof/pillar/commit/2a956146c6ed6d3137ba59ecb3752718c03882a9
-* add replication strategy support [#9]:https://github.com/Galeria-Kaufhof/pillar/pull/9
-* small bugfixes
- 
-### 3.3.0
- * initialize-method split up into two methods (createKeyspace and createMigrationsTable). 

--- a/project/PillarBuild.scala
+++ b/project/PillarBuild.scala
@@ -16,7 +16,7 @@ object PillarBuild extends Build {
   }
 
   val dependencies = Seq(
-    "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.0",
+    "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.2",
     "com.typesafe" % "config" % "1.0.1",
     "org.clapper" %% "argot" % "1.0.3",
     "org.mockito" % "mockito-core" % "1.9.5" % "test",

--- a/src/main/resources/cassandraConnectionReference.conf
+++ b/src/main/resources/cassandraConnectionReference.conf
@@ -1,6 +1,8 @@
 cassandra-seed-address: "127.0.0.1"
 cassandra-port: 9042
 use-ssl: false
+applied-migrations-table-name: "applied_migrations"
+
 #auth {
 #  username: cassandra-user
 #  password: secret

--- a/src/main/scala/de/kaufhof/pillar/AppliedMigrations.scala
+++ b/src/main/scala/de/kaufhof/pillar/AppliedMigrations.scala
@@ -6,8 +6,8 @@ import scala.collection.JavaConversions
 import java.util.Date
 
 object AppliedMigrations {
-  def apply(session: Session, registry: Registry): AppliedMigrations = {
-    val results = session.execute(QueryBuilder.select("authored_at", "description").from("applied_migrations"))
+  def apply(session: Session, registry: Registry, appliedMigrationsTableName: String): AppliedMigrations = {
+    val results = session.execute(QueryBuilder.select("authored_at", "description").from(appliedMigrationsTableName))
     new AppliedMigrations(JavaConversions.asScalaBuffer(results.all()).map {
       row => registry(MigrationKey(row.getTimestamp("authored_at"), row.getString("description")))
     })

--- a/src/main/scala/de/kaufhof/pillar/CassandraMigrator.scala
+++ b/src/main/scala/de/kaufhof/pillar/CassandraMigrator.scala
@@ -3,16 +3,20 @@ package de.kaufhof.pillar
 import java.util.Date
 
 import com.datastax.driver.core.Session
-import com.datastax.driver.core.exceptions.AlreadyExistsException
 
-class CassandraMigrator(registry: Registry) extends Migrator {
+object CassandraMigrator {
+  val appliedMigrationsTableNameDefault = "applied_migrations"
+}
+
+class CassandraMigrator(registry: Registry, appliedMigrationsTableName: String) extends Migrator {
   override def migrate(session: Session, dateRestriction: Option[Date] = None) {
-    val appliedMigrations = AppliedMigrations(session, registry)
-    selectMigrationsToReverse(dateRestriction, appliedMigrations).foreach(_.executeDownStatement(session))
-    selectMigrationsToApply(dateRestriction, appliedMigrations).foreach(_.executeUpStatement(session))
+    val appliedMigrations = AppliedMigrations(session, registry, appliedMigrationsTableName)
+    selectMigrationsToReverse(dateRestriction, appliedMigrations).foreach(_.executeDownStatement(session, appliedMigrationsTableName))
+    selectMigrationsToApply(dateRestriction, appliedMigrations).foreach(_.executeUpStatement(session, appliedMigrationsTableName))
   }
 
-  override def initialize(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy) {
+  override def initialize(session: Session, keyspace: String,
+                          replicationStrategy: ReplicationStrategy = SimpleStrategy()) {
     createKeyspace(session, keyspace, replicationStrategy)
     createMigrationsTable(session, keyspace)
   }
@@ -24,13 +28,13 @@ class CassandraMigrator(registry: Registry) extends Migrator {
   override def createMigrationsTable(session: Session, keyspace: String) = {
     session.execute(
       """
-        | CREATE TABLE IF NOT EXISTS %s.applied_migrations (
+        | CREATE TABLE IF NOT EXISTS %s.%s (
         |   authored_at timestamp,
         |   description text,
         |   applied_at timestamp,
         |   PRIMARY KEY (authored_at, description)
         |  )
-      """.stripMargin.format(keyspace)
+      """.stripMargin.format(keyspace, appliedMigrationsTableName)
     )
   }
 

--- a/src/main/scala/de/kaufhof/pillar/Migrator.scala
+++ b/src/main/scala/de/kaufhof/pillar/Migrator.scala
@@ -5,21 +5,21 @@ import java.util.Date
 import com.datastax.driver.core.Session
 
 object Migrator {
-  def apply(registry: Registry): Migrator = {
-    new CassandraMigrator(registry)
+  def apply(registry: Registry, appliedMigrationsTableName: String): Migrator = {
+    new CassandraMigrator(registry, appliedMigrationsTableName)
   }
 
-  def apply(registry: Registry, reporter: Reporter): Migrator = {
-    new ReportingMigrator(reporter, apply(registry))
+  def apply(registry: Registry, reporter: Reporter, appliedMigrationsTableName: String): Migrator = {
+    new ReportingMigrator(reporter, apply(registry, appliedMigrationsTableName), appliedMigrationsTableName)
   }
 }
 
 trait Migrator {
   def migrate(session: Session, dateRestriction: Option[Date] = None)
 
-  def initialize(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy = SimpleStrategy())
+  def initialize(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy)
 
-  def createKeyspace(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy = SimpleStrategy())
+  def createKeyspace(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy)
 
   def createMigrationsTable(session: Session, keyspace: String)
 

--- a/src/main/scala/de/kaufhof/pillar/PrintStreamReporter.scala
+++ b/src/main/scala/de/kaufhof/pillar/PrintStreamReporter.scala
@@ -27,8 +27,8 @@ class PrintStreamReporter(stream: PrintStream) extends Reporter {
     stream.println(s"Creating keyspace $keyspace")
   }
 
-  override def creatingMigrationsTable(session: Session, keyspace: String): Unit = {
-    stream.println(s"Creating migrations-table in keyspace $keyspace")
+  override def creatingMigrationsTable(session: Session, keyspace: String, appliedMigrationsTableName: String): Unit = {
+    stream.println(s"Creating migrations-table [$appliedMigrationsTableName] in keyspace $keyspace")
   }
 
 }

--- a/src/main/scala/de/kaufhof/pillar/Reporter.scala
+++ b/src/main/scala/de/kaufhof/pillar/Reporter.scala
@@ -10,5 +10,5 @@ trait Reporter {
   def reversing(migration: Migration)
   def destroying(session: Session, keyspace: String)
   def creatingKeyspace(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy)
-  def creatingMigrationsTable(session: Session, keyspace: String)
+  def creatingMigrationsTable(session: Session, keyspace: String, appliedMigrationsTableName: String)
 }

--- a/src/main/scala/de/kaufhof/pillar/ReportingMigration.scala
+++ b/src/main/scala/de/kaufhof/pillar/ReportingMigration.scala
@@ -8,13 +8,13 @@ class ReportingMigration(reporter: Reporter, wrapped: Migration) extends Migrati
   val authoredAt: Date = wrapped.authoredAt
   val up: String = wrapped.up
 
-  override def executeUpStatement(session: Session) {
+  override def executeUpStatement(session: Session, appliedMigrationsTableName: String) {
     reporter.applying(wrapped)
-    wrapped.executeUpStatement(session)
+    wrapped.executeUpStatement(session, appliedMigrationsTableName)
   }
 
-  def executeDownStatement(session: Session) {
+  def executeDownStatement(session: Session, appliedMigrationsTableName: String) {
     reporter.reversing(wrapped)
-    wrapped.executeDownStatement(session)
+    wrapped.executeDownStatement(session, appliedMigrationsTableName)
   }
 }

--- a/src/main/scala/de/kaufhof/pillar/ReportingMigrator.scala
+++ b/src/main/scala/de/kaufhof/pillar/ReportingMigrator.scala
@@ -4,7 +4,7 @@ import java.util.Date
 
 import com.datastax.driver.core.Session
 
-class ReportingMigrator(reporter: Reporter, wrapped: Migrator) extends Migrator {
+class ReportingMigrator(reporter: Reporter, wrapped: Migrator, appliedMigrationsTableName: String) extends Migrator {
   override def initialize(session: Session, keyspace: String, replicationStrategy: ReplicationStrategy) {
     createKeyspace(session, keyspace, replicationStrategy)
     createMigrationsTable(session, keyspace)
@@ -26,7 +26,7 @@ class ReportingMigrator(reporter: Reporter, wrapped: Migrator) extends Migrator 
   }
 
   override def createMigrationsTable(session: Session, keyspace: String): Unit = {
-    reporter.creatingMigrationsTable(session, keyspace)
+    reporter.creatingMigrationsTable(session, keyspace, appliedMigrationsTableName)
     wrapped.createMigrationsTable(session, keyspace)
   }
 }

--- a/src/main/scala/de/kaufhof/pillar/cli/App.scala
+++ b/src/main/scala/de/kaufhof/pillar/cli/App.scala
@@ -55,7 +55,9 @@ class App(reporter: Reporter, configuration: Config) {
       cassandraConfiguration.keyspace,
       commandLineConfiguration.timeStampOption,
       registry,
-      replicationOptions)
+      replicationOptions,
+      cassandraConfiguration.appliedMigrationsTableName
+    )
 
     try {
       CommandExecutor().execute(command, reporter)

--- a/src/main/scala/de/kaufhof/pillar/cli/Command.scala
+++ b/src/main/scala/de/kaufhof/pillar/cli/Command.scala
@@ -3,4 +3,5 @@ package de.kaufhof.pillar.cli
 import de.kaufhof.pillar.{Registry, ReplicationStrategy}
 import com.datastax.driver.core.Session
 
-case class Command(action: MigratorAction, session: Session, keyspace: String, timeStampOption: Option[Long], registry: Registry, replicationStrategy: ReplicationStrategy)
+case class Command(action: MigratorAction, session: Session, keyspace: String, timeStampOption: Option[Long],
+                   registry: Registry, replicationStrategy: ReplicationStrategy, appliedMigrationsTableName: String)

--- a/src/main/scala/de/kaufhof/pillar/cli/CommandExecutor.scala
+++ b/src/main/scala/de/kaufhof/pillar/cli/CommandExecutor.scala
@@ -5,14 +5,14 @@ import java.util.Date
 import de.kaufhof.pillar.{Migrator, Registry, Reporter}
 
 object CommandExecutor {
-  implicit private val migratorConstructor: ((Registry, Reporter) => Migrator) = Migrator.apply
+  implicit private val migratorConstructor: ((Registry, Reporter, String) => Migrator) = Migrator.apply
 
   def apply(): CommandExecutor = new CommandExecutor()
 }
 
-class CommandExecutor(implicit val migratorConstructor: ((Registry, Reporter) => Migrator)) {
+class CommandExecutor(implicit val migratorConstructor: ((Registry, Reporter, String) => Migrator)) {
   def execute(command: Command, reporter: Reporter) {
-    val migrator = migratorConstructor(command.registry, reporter)
+    val migrator = migratorConstructor(command.registry, reporter, command.appliedMigrationsTableName)
 
     command.action match {
       case Initialize => migrator.initialize(command.session, command.keyspace, command.replicationStrategy)

--- a/src/main/scala/de/kaufhof/pillar/config/ConnectionConfiguration.scala
+++ b/src/main/scala/de/kaufhof/pillar/config/ConnectionConfiguration.scala
@@ -23,6 +23,7 @@ class ConnectionConfiguration(dataStoreName: String, environment: String, appCon
   import ConfigHelper.toOptionalConfig
 
   val auth = Auth(connectionConfig.getOptionalConfig("auth"))
+  val appliedMigrationsTableName = connectionConfig.getOptionalString("applied-migrations-table-name").getOrElse("applied_migrations")
 
   val sslConfig: Option[SslConfig] = SslConfig(connectionConfig.getOptionalConfig("ssl-options"))
 

--- a/src/test/scala/de/kaufhof/pillar/AcceptanceAssertions.scala
+++ b/src/test/scala/de/kaufhof/pillar/AcceptanceAssertions.scala
@@ -8,8 +8,8 @@ trait AcceptanceAssertions extends ShouldMatchers {
   val session: Session
   val keyspaceName: String
 
-  protected def assertEmptyAppliedMigrationsTable() {
-    session.execute(QueryBuilder.select().from(keyspaceName, "applied_migrations")).all().size() should equal(0)
+  protected def assertEmptyAppliedMigrationsTable(appliedMigrationsTableName: String = "applied_migrations") {
+    session.execute(QueryBuilder.select().from(keyspaceName, appliedMigrationsTableName)).all().size() should equal(0)
   }
 
   protected def assertKeyspaceDoesNotExist() {

--- a/src/test/scala/de/kaufhof/pillar/PrintStreamReporterSpec.scala
+++ b/src/test/scala/de/kaufhof/pillar/PrintStreamReporterSpec.scala
@@ -16,6 +16,7 @@ class PrintStreamReporterSpec extends FunSpec with MockitoSugar with Matchers wi
   val keyspace = "myks"
   val replicationStrategy = SimpleStrategy()
   val nl = System.lineSeparator()
+  val appliedMigrationsTableName = "applied_migrations"
 
   describe("#creatingKeyspace") {
     it("should print to the stream") {
@@ -26,8 +27,8 @@ class PrintStreamReporterSpec extends FunSpec with MockitoSugar with Matchers wi
 
   describe("#creatingMigrationsTable") {
     it("should print to the stream") {
-      reporter.creatingMigrationsTable(session, keyspace)
-      output.toString should equal(s"Creating migrations-table in keyspace myks${nl}")
+      reporter.creatingMigrationsTable(session, keyspace, appliedMigrationsTableName)
+      output.toString should equal(s"Creating migrations-table [$appliedMigrationsTableName] in keyspace myks${nl}")
     }
   }
 

--- a/src/test/scala/de/kaufhof/pillar/ReportingMigrationSpec.scala
+++ b/src/test/scala/de/kaufhof/pillar/ReportingMigrationSpec.scala
@@ -12,28 +12,29 @@ class ReportingMigrationSpec extends FunSpec with ShouldMatchers with MockitoSug
   val wrapped = mock[Migration]
   val migration = new ReportingMigration(reporter, wrapped)
   val session = mock[Session]
+  val appliedMigrationsTableName = "applied_migrations"
 
   describe("#executeUpStatement") {
-    migration.executeUpStatement(session)
+    migration.executeUpStatement(session, appliedMigrationsTableName)
 
     it("reports the applying action") {
       verify(reporter).applying(wrapped)
     }
 
     it("delegates to the wrapped migration") {
-      verify(wrapped).executeUpStatement(session)
+      verify(wrapped).executeUpStatement(session, appliedMigrationsTableName)
     }
   }
 
   describe("#executeDownStatement") {
-    migration.executeDownStatement(session)
+    migration.executeDownStatement(session, appliedMigrationsTableName)
 
     it("reports the reversing action") {
       verify(reporter).reversing(wrapped)
     }
 
     it("delegates to the wrapped migration") {
-      verify(wrapped).executeDownStatement(session)
+      verify(wrapped).executeDownStatement(session, appliedMigrationsTableName)
     }
   }
 }

--- a/src/test/scala/de/kaufhof/pillar/ReportingMigratorSpec.scala
+++ b/src/test/scala/de/kaufhof/pillar/ReportingMigratorSpec.scala
@@ -8,7 +8,8 @@ import org.scalatest.mock.MockitoSugar
 class ReportingMigratorSpec extends FunSpec with MockitoSugar {
   val reporter = mock[Reporter]
   val wrapped = mock[Migrator]
-  val migrator = new ReportingMigrator(reporter, wrapped)
+  val appliedMigrationsTableName = "applied_migrations"
+  val migrator = new ReportingMigrator(reporter, wrapped, appliedMigrationsTableName)
   val session = mock[Session]
   val keyspace = "myks"
 


### PR DESCRIPTION
Added the option to specify the name of the applied_migrations table in which the migrations are stored. This is useful when using pillar in a muli-module/multi-service setup where the services have their own non shared tables but live both in the same keyspace and should be deployed independently from each other.
