### PR TITLE
Add support for scala 2.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: scala
 jdk:
    - oraclejdk8
 scala:
+   - 2.10.6
    - 2.11.11
    - 2.12.2

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ The RPM installs Pillar to /opt/pillar.
 
 ### Packages
 
-Pillar is available at Maven Central under the GroupId de.kaufhof and ArtifactId pillar_2.10, pillar_2.11 or pillar_2.12. 
-The current version of pillar_2.11/pillar_2.12 is 4.1.0.
+Pillar is available at Maven Central under the GroupId de.kaufhof and ArtifactId pillar_2.10, pillar_2.11 or pillar_2.12. The current version of pillar is 4.1.0.
 
 #### sbt
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The RPM installs Pillar to /opt/pillar.
 
 ### Packages
 
-Pillar is available at Maven Central under the GroupId de.kaufhof and ArtifactId pillar_2.11 or pillar_2.12.
-pillar_2.10 is no longer supported. The current version of pillar_2.11/pillar_2.12 is 4.1.0.
+Pillar is available at Maven Central under the GroupId de.kaufhof and ArtifactId pillar_2.10, pillar_2.11 or pillar_2.12. 
+The current version of pillar_2.11/pillar_2.12 is 4.1.0.
 
 #### sbt
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,7 @@ lazy val root = Project(
     licenses := Seq("MIT license" -> url(
       "http://www.opensource.org/licenses/mit-license.php")),
     scalaVersion := "2.12.2",
-    crossScalaVersions := Seq("2.12.2", "2.11.11")
+    crossScalaVersions := Seq("2.12.2", "2.11.11", "2.10.6")
   )
   .settings(
     publishTo := {


### PR DESCRIPTION
Since sbt doesn't allow the use of 2.11 or 2.12 packages when creating plugins, it would be very useful to have this project building 2.10 artifacts. This way projects like https://github.com/inoio/sbt-pillar-plugin can update to the latest version of pillar.