### PR TITLE
NetworkTopologyStrategy cql string places 2 spaces before the closing right bracket

### DIFF
--- a/src/main/scala/de/kaufhof/pillar/ReplicationStrategy.scala
+++ b/src/main/scala/de/kaufhof/pillar/ReplicationStrategy.scala
@@ -20,10 +20,10 @@ final case class NetworkTopologyStrategy(dataCenters: Seq[CassandraDataCenter]) 
 
   override def cql: String = {
     val replicationFacString = dataCenters.map { dc =>
-      s"'${dc.name}' : ${dc.replicationFactor} "
-    }.mkString(", ")
+      s"'${dc.name}' : ${dc.replicationFactor}"
+    }.mkString(" , ")
 
-    s"{'class' : 'NetworkTopologyStrategy', $replicationFacString }"
+    s"{'class' : 'NetworkTopologyStrategy', $replicationFacString}"
   }
 }
 


### PR DESCRIPTION
This is a small pr to remove the trailing 2 spaces in the NetworkTopologyStrategy datacenter list in the cql string:
`{'class' : 'NetworkTopologyStrategy', 'dc1' : 3 , 'dc2' : 3  }`
to
`{'class' : 'NetworkTopologyStrategy', 'dc1' : 3 , 'dc2' : 3}`

For reference, the SimpleStrategy looks like:
`{'class' : 'SimpleStrategy', 'replication_factor' : 1}`